### PR TITLE
Replace watch button with player image

### DIFF
--- a/app/templates/content/view.html
+++ b/app/templates/content/view.html
@@ -25,11 +25,18 @@
                     <div class="row">
                         <div class="col-md-4">
                             {% if content.thumbnail %}
-                                <img src="{{ content.thumbnail }}" class="img-fluid rounded" alt="{{ content.title }}">
+                                <a href="{{ content.url }}" target="_blank" class="thumbnail-overlay-link d-block position-relative rounded overflow-hidden">
+                                    <img src="{{ content.thumbnail }}" class="img-fluid rounded" alt="{{ content.title }}">
+                                    <span class="thumbnail-play-overlay d-flex align-items-center justify-content-center">
+                                        <i class="fas fa-play-circle"></i>
+                                    </span>
+                                </a>
                             {% else %}
-                                <div class="bg-light d-flex align-items-center justify-content-center rounded" style="height: 300px;">
-                                    <i class="fas fa-play-circle fa-5x text-muted"></i>
-                                </div>
+                                <a href="{{ content.url }}" target="_blank" class="thumbnail-overlay-link d-block position-relative rounded overflow-hidden" style="height: 300px;">
+                                    <div class="bg-light w-100 h-100 d-flex align-items-center justify-content-center">
+                                        <i class="fas fa-play-circle fa-5x text-muted"></i>
+                                    </div>
+                                </a>
                             {% endif %}
                         </div>
                         
@@ -46,13 +53,7 @@
                                 <p>{{ content.description }}</p>
                             {% endif %}
                             
-                            {% if content.url %}
-                                <div class="mb-3">
-                                    <a href="{{ content.url }}" target="_blank" class="btn btn-success">
-                                        <i class="fas fa-external-link-alt"></i> Assistir
-                                    </a>
-                                </div>
-                            {% endif %}
+                            {# Removed the separate green Assistir button; the thumbnail is now clickable #}
                             
                             <div class="text-muted">
                                 <small>Adicionado em {{ content.created_at.strftime('%d de %B de %Y às %H:%M') }}</small>


### PR DESCRIPTION
Replace the "Assistir" button with a clickable play icon overlay on YouTube video thumbnails to improve visual appeal and direct access.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e9d24e8-d4e5-4bb9-ae10-7f33b62377dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0e9d24e8-d4e5-4bb9-ae10-7f33b62377dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

