### PR TITLE
Center and resize thumbnail player icon

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -514,3 +514,31 @@ h1, h2, h3, h4, h5, h6 {
 ::-webkit-scrollbar-thumb:hover {
     background: linear-gradient(135deg, var(--color-primary-700) 0%, var(--color-primary-600) 100%);
 }
+
+/* Thumbnail play overlay: center the play icon over the thumbnail */
+.thumbnail-overlay-link .thumbnail-play-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none; /* ensure the link remains clickable */
+    z-index: 1;
+}
+
+.thumbnail-overlay-link .thumbnail-play-overlay i {
+    font-size: 3rem; /* adjust as needed */
+    color: #ffffff;
+    margin: 0; /* override global icon margin */
+    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+    transition: transform 0.15s ease-in-out;
+}
+
+.thumbnail-overlay-link:hover .thumbnail-play-overlay i {
+    transform: scale(1.06);
+}


### PR DESCRIPTION
Center and enlarge the play icon on video thumbnails to improve visibility and positioning.

The original play icon was tiny and positioned incorrectly, often outside the thumbnail, which made it hard to see and not visually aligned with standard video players. This change adds CSS to correctly center and size the icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d112aab-cd36-45f7-981d-bfc06c4c31f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d112aab-cd36-45f7-981d-bfc06c4c31f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

