### PR TITLE
Style green alert to match white/blue

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -362,9 +362,9 @@ h2 {
 }
 
 .alert-success {
-    background: rgba(40, 167, 69, 0.1);
-    border-left-color: #28a745;
-    color: #155724;
+    background: rgba(23, 162, 184, 0.1);
+    border-left-color: #17a2b8;
+    color: #0c5460;
 }
 
 .alert-danger {


### PR DESCRIPTION
Update the style of the success alert to match the visual style of the info alert.

---
<a href="https://cursor.com/background-agent?bcId=bc-525c84a1-7847-4f1b-8e5b-f4d8c63923fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-525c84a1-7847-4f1b-8e5b-f4d8c63923fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

